### PR TITLE
Fix invalid Debian/Ubuntu packages

### DIFF
--- a/en/install.rst
+++ b/en/install.rst
@@ -20,7 +20,7 @@ If you're using Ubuntu, you can install the required packages this way:
 .. code-block:: bash
 
 	$ sudo apt-get update
-	$ sudo apt-get install git gcc make re2c php5 php5-json php5-dev libpcre3-dev
+	$ sudo apt-get install git gcc make re2c php7.0 php7.0-json php7.0-dev libpcre3-dev
 
 Since Zephir is written in PHP you need to have installed a recent version of PHP and it must be available in your console:
 

--- a/ru/install.rst
+++ b/ru/install.rst
@@ -19,7 +19,7 @@
 .. code-block:: bash
 
 	$ sudo apt-get update
-	$ sudo apt-get install git gcc make re2c php5 php5-json php5-dev libpcre3-dev
+	$ sudo apt-get install git gcc make re2c php7.0 php7.0-json php7.0-dev libpcre3-dev
 
 Так как Zephir написан на PHP, вам нужно установить последнюю версию PHP.
 PHP должен быть доступен из консоли:

--- a/zh/install.rst
+++ b/zh/install.rst
@@ -20,7 +20,7 @@ To install Zephir, please follow these steps:
 .. code-block:: bash
 
 	$ sudo apt-get update
-	$ sudo apt-get install git gcc make re2c php5 php5-json php5-dev libpcre3-dev
+	$ sudo apt-get install git gcc make re2c php7.0 php7.0-json php7.0-dev libpcre3-dev
 
 因为Zephir是用PHP编写的，所以你需要安装最新版本的PHP和控制台:
 


### PR DESCRIPTION
Hello!

Wouldn't it be more logical to advice users to install 7.0 related packages?

1. 5.* branch support is going to be dropped soon.

![image](https://cloud.githubusercontent.com/assets/100198/21235907/fe53f90e-c322-11e6-9a24-576c27a398ac.png)

2. You already mention 7.0 just a bit below that line:

![image](https://cloud.githubusercontent.com/assets/100198/21235667/ee978810-c321-11e6-921c-522062e1e462.png)

```
$ screenfetch
         _,met$$$$$gg.           resurtm@resurtm-desktop
      ,g$$$$$$$$$$$$$$$P.        OS: Debian testing stretch
    ,g$$P""       """Y$$.".      Kernel: x86_64 Linux 4.8.0-1-amd64
   ,$$P'              `$$$.      Uptime: 12h 56m
  ',$$P       ,ggs.     `$$b:    Packages: 1856
  `d$$'     ,$P"'   .    $$$     Shell: bash 4.4.5
   $$P      d$'     ,    $$P     Resolution: 1920x1200
   $$:      $$.   -    ,d$$'     DE: XFCE
   $$\;      Y$b._   _,d$P'      WM: Xfwm4
   Y$$.    `.`"Y$$$$P"'          WM Theme: Default
   `$$b      "-.__               GTK Theme: Adwaita [GTK2]
    `Y$$                         Icon Theme: Tango
     `Y$$.                       Font: Sans 10
       `$$b.                     CPU: Intel Core i5 CPU 760 @ 2.801GHz
         `Y$$b.                  GPU: GeForce GT 640/PCIe/SSE2
            `"Y$b._              RAM: 6413MiB / 16041MiB
                `""""            
```

```
$ apt search php5-json
Sorting... Done
Full Text Search... Done

$ apt search php5-dev
Sorting... Done
Full Text Search... Done

$ apt search php7.0-dev
Sorting... Done
Full Text Search... Done
php-all-dev/testing,testing 1:46 all
  package depending on all supported PHP development packages

php7.0-dev/testing,now 7.0.13-2 amd64 [installed]
  Files for PHP7.0 module development

$ apt search php7.0-json
Sorting... Done
Full Text Search... Done
php7.0-json/testing,now 7.0.13-2 amd64 [installed]
  JSON module for PHP
```